### PR TITLE
Make title attribute conditional

### DIFF
--- a/Parsefile/Global_head.html
+++ b/Parsefile/Global_head.html
@@ -2,7 +2,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
 <meta content="IE=edge" http-equiv="X-UA-Compatible" />
 <link rel="icon" href="./?a=1456044" type="image/gif" sizes="16x16">
-<title>%globals_asset_metadata_Title%</title>
+<title>%begin_globals_asset_metadata_Title%%globals_asset_metadata_Title%%else_globals_asset_metadata_Title%%globals_asset_name%%end_globals_asset_metadata_Title%</title>
 <!--
 This website is managed centrally by the External Relations Digital Team. digital-team@unimelb.edu.au
 Last updated by: %globals_asset_updated_by_name% on %globals_asset_updated_readable%


### PR DESCRIPTION
The current title attribute requires a “Title” attribute to be set via
metadata. This doesn’t work for assets that don’t use “Title”.

This change prints the asset name in the absence of a Title attribute.