### PR TITLE
Use canonical link in go:url attribute if present

### DIFF
--- a/Parsefile/Global_head.html
+++ b/Parsefile/Global_head.html
@@ -38,7 +38,7 @@ Web maintainer: %globals_site_metadata_SITE.MaintainerEmail%
 <!--@@ -------------- Metatags end for funnelback  ------------------ @@-->
 <!--@@ -------------- Social Media start ---------------------------- @@-->
 <meta property="og:type" content="website" />
-<meta property="og:url" content="%globals_asset_url%" />
+<meta property="og:url" content="%begin_globals_asset_metadata_Canonical%%globals_asset_metadata_Canonical%%else_globals_asset_metadata_Canonical%%globals_asset_url%%end_globals_asset_metadata_Canonical%" />
 <meta property="og:title" content="%globals_asset_metadata_Title%" />
 <meta property="og:description" content="%globals_asset_metadata_description%" />
 <meta property="og:site_name" content="%globals_site_name%" />


### PR DESCRIPTION
Prevents conflict between link re=“canonical” tag and og:url attribute